### PR TITLE
Fix typo in build badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SE-Proj22-Team11
 
 Current Build Status:
-![example workflow](https://github.com/Surya-06/SE-Proj22-Team11/actions/workflows/build-test.yml/badge.svg)
+![example workflow](https://github.com/Surya-06/SE-Proj22-Team11/actions/workflows/build-test.yaml/badge.svg)
 
 NCSU Fall 22 SE proj repo for Team 11


### PR DESCRIPTION
- Correct file name in API param from '.yml' to '.yaml' to fix badge issue in readme.